### PR TITLE
mdi package was renamed

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "nuxt": "3.0.0-rc.1"
   },
   "dependencies": {
-    "mdi": "^2.2.43",
+    "@mdi/font": "^7.0.96"    
     "sass": "^1.51.0",
     "vuetify": "^3.0.0-beta.1"
   }


### PR DESCRIPTION
From the author of mdi:
"The mdi package was renamed to @mdi/font after v2.2.43. Please rename in your package.json for future updates."